### PR TITLE
Update graph.py

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -20,7 +20,7 @@ def m_b_data(m, b, x_values):
     y_values = list(map(lambda x: m*x + b, x_values))
     return {'x': x_values, 'y': y_values}
 
-def m_b_trace(m, b, x_values, mode = 'line', name = 'line function'):
+def m_b_trace(m, b, x_values, mode = 'lines', name = 'line function'):
     values = m_b_data(m, b, x_values)
     values.update({'mode': mode, 'name': name})
     return values


### PR DESCRIPTION
simple error of a dropped 's'
'mode': 'line' creates an error changed to 'mode': 'lines' in the function
this has created errors every time the lessons are run in the datascience bootcamp prep  which is VERY confusing for people trying to learn. 